### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,6 @@
 
 version: 2
 updates:
-  # Maintain dependencies for NuGet
-  - package-ecosystem: "nuget" # See documentation for possible values
-    directory: "AzDoExtensionNews" # Location of package manifests
-    schedule:
-      interval: "monthly"
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
This pull request includes a change in the `.github/dependabot.yml` file. The change removes the section that maintains dependencies for NuGet. This means that Dependabot will no longer automatically check for and create pull requests for updates to NuGet packages in the `AzDoExtensionNews` directory on a monthly schedule.