### PR TITLE
fix: move permissions to job level in create-test-issue workflow

### DIFF
--- a/.github/workflows/create-test-issue.yaml
+++ b/.github/workflows/create-test-issue.yaml
@@ -9,14 +9,15 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Permissions needed for issue creation
-permissions:
-  issues: write
-  contents: read
+# No workflow-level permissions - defined at job level
+permissions: {}
 
 jobs:
   create-test-issue:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1


### PR DESCRIPTION
## Summary

Moves permissions from workflow level to job level in \create-test-issue.yaml\, following the principle of least privilege documented in \copilot-instructions.md\.

## Changes
- \.github/workflows/create-test-issue.yaml\: set \permissions: {}\ at workflow level, added \permissions: issues: write / contents: read\ at job level

## Why
The repo's own \copilot-instructions.md\ mandates job-level permissions. This workflow was not compliant.