### PR TITLE
chore: update Hugo from 0.115.4 to 0.160.1

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -36,7 +36,7 @@ jobs:
     outputs:
       build_had_failures: ${{ steps.hugo_build.outputs.build_had_failures }}
     env:
-      HUGO_VERSION: 0.115.4
+      HUGO_VERSION: 0.160.1
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fe104658747b27e96e4f7e80cd0a94068e53901d # v2.16.1


### PR DESCRIPTION
## Summary

Updates Hugo from the outdated v0.115.4 (July 2023) to the latest stable release.

## Changes
- `.github/workflows/hugo.yaml`: bumped `HUGO_VERSION`

## Why
Over 2 years of bug fixes, performance improvements, and security patches were being missed.