### PR TITLE
docs: add AGENTS.md pointing to copilot-instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+AI agent instructions for this repository are maintained in [copilot-instructions.md](copilot-instructions.md).


### PR DESCRIPTION
## Summary

Adds an `AGENTS.md` file to the repo root so AI coding agents automatically discover the existing `copilot-instructions.md`.

## Changes
- Added `AGENTS.md` at repo root

## Why
`AGENTS.md` is the standard convention for AI agents to find repository-specific instructions. The instructions file already exists and is comprehensive — this just makes it discoverable.