### PR TITLE
fix: update single.html for Ananke v2.12.1 and enable raw HTML

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -34,5 +34,8 @@ Paginate = 9
     name = "mastodon"
     url = "https://mstdn.social/@Rob_Bos"
     rel = "me noopener"
+[markup.goldmark.renderer]
+  unsafe = true
+
 [permalinks]
   posts = '/blog/:year/:month/:day/:title/'

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,38 +1,41 @@
 {{ define "header" }}
    {{/* We can override any block in the baseof file be defining it in the template */}}
-  {{ partial "page-header.html" . }}
+  {{ partials.Include "page-header.html" . }}
 {{ end }}
 
 {{ define "main" }}
+  {{ $page := .}}
   {{ $section := .Site.GetPage "section" .Section }}
-  <article class="flex-l flex-wrap justify-between mw8 center ph3">
+  <article class="flex-l mw8 center ph3 flex-wrap justify-between">
     <header class="mt4 w-100">
-      <aside class="instapaper_ignoref b helvetica tracked">
+      <aside class="instapaper_ignoref b helvetica tracked ttu">
           {{/*
           CurrentSection allows us to use the section title instead of inferring from the folder.
           https://gohugo.io/variables/page/#section-variables-and-methods
           */}}
-        {{with .CurrentSection.Title }}{{. | upper }}{{end}}
+        {{ .CurrentSection.Title }}
       </aside>
-      {{ partial "social-share.html" . }}
+      {{- partials.IncludeCached "social/share.html" . . -}}
       <h1 class="f1 athelas mt3 mb1">
         {{- .Title -}}
       </h1>
-      {{ with .Params.author | default .Site.Params.author }}
+      {{ with .Params.author | compare.Default .Site.Params.author }}
       <p class="tracked">
-        {{ $.Render "by" }} <strong>
+        {{- if compare.Eq $page.Language "de" "en" "es" "fr" "it" "no" "pt" -}}
+          {{- lang.Translate "by" -}}
+        {{ end -}} <strong>
         {{- if reflect.IsSlice . -}}
-            {{ delimit . ", " | markdownify }}
+            {{ collections.Delimit . ", " | transform.Markdownify }}
         {{- else -}}
-            {{ . | markdownify }}
+            {{ . | transform.Markdownify }}
         {{- end -}}
         </strong>
       </p>
       {{ end }}
       {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
       {{ if not .Date.IsZero }}
-      <time class="f6 mv4 dib tracked" {{ printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safeHTMLAttr }}>
-        {{- .Date | time.Format (default "January 2, 2006" .Site.Params.date_format) -}}
+      <time class="f6 mv4 dib tracked" {{ fmt.Printf `datetime="%s"` (.Date.Format "2006-01-02T15:04:05Z07:00") | safe.HTMLAttr }}>
+        {{- .Date | time.Format (compare.Default "January 2, 2006" .Site.Params.date_format) -}}
       </time>
       {{end}}
 
@@ -42,26 +45,26 @@
           2) A section front matter value is set `show_reading_time = true`
           3) A page front matter value is set `show_reading_time = true`
         */}}
-      {{ if (or (eq (.Param "show_reading_time") true) (eq $section.Params.show_reading_time true) )}}
-        <span class="f6 mv4 dib tracked"> - {{ i18n "readingTime" .ReadingTime }} </span>
-        <span class="f6 mv4 dib tracked"> - {{ i18n "wordCount" .WordCount }} </span>
+      {{ if (or (compare.Eq (.Param "show_reading_time") true) (compare.Eq $section.Params.show_reading_time true) )}}
+        <span class="f6 mv4 dib tracked"> - {{ lang.Translate "readingTime" .ReadingTime }} </span>
+        <span class="f6 mv4 dib tracked"> - {{ lang.Translate "wordCount" .WordCount }} </span>
       {{ end }}
     </header>
-    <div class="nested-copy-line-height lh-copy {{ $.Param "post_content_classes"  | default "serif"}} f4 nested-links {{ $.Param "text_color" | default "mid-gray" }} {{ cond (eq $.Site.Language.LanguageDirection "rtl") "pl4-l" "pr4-l" }} w-two-thirds-l">
+    <div class="nested-copy-line-height lh-copy {{ $.Param "post_content_classes"  | compare.Default "serif"}} f4 nested-links {{ $.Param "text_color" | compare.Default "mid-gray" }} {{ compare.Conditional (compare.Eq $.Site.Language.LanguageDirection "rtl") "pl4-l" "pr4-l" }} w-two-thirds-l">
       {{- .Content -}}
-      {{- partial "tags.html" . -}}
+      {{- partials.Include "tags.html" . -}}
       <div class="mt6 instapaper_ignoref">
-      {{ if .Site.DisqusShortname }}
+      {{ if .Site.Config.Services.Disqus.Shortname }}
         {{ template "_internal/disqus.html" . }}
       {{ end }}
       {{ if .Site.Params.commentoEnable }}
-        {{- partial "commento.html" . -}}
+        {{- partials.Include "commento.html" . -}}
       {{ end }}
       </div>
     </div>
 
     <aside class="w-30-l mt6-l">
-      {{- partial "menu-contextual.html" . -}}
+      {{- partials.Include "menu-contextual.html" . -}}
     </aside>
 
     {{ if .Page.Store.Get "hasMermaid" }}


### PR DESCRIPTION
Fixes two errors from run https://github.com/devops-actions/github-actions-marketplace-news/actions/runs/24790279742/job/72545556078 after PR #55 merged. 1) partial social-share.html not found - updated to social/share.html with new partials.IncludeCached API; also updated other deprecated template calls. 2) Raw HTML omitted warnings - added markup.goldmark.renderer unsafe=true to hugo.toml.