### PR TITLE
fix: remove .Site.Author references and duplicate About menu entry

### DIFF
--- a/content/about.md
+++ b/content/about.md
@@ -1,8 +1,5 @@
 ---
 title: "About"
-menu:
-  main:
-    weight: 1
 type: single
 ---
 GitHub Actions does not have a way to stay up to date with the extension updates or new extensions being added. This site will show you the updates and has an RSS feed option to see updates in your favorite RSS tool. Made by [Rob Bos](https://github.com/rajbos).

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -17,9 +17,7 @@
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne  .Title  .Site.Title }}{{ with .Title }}in {{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>{{ with .Site.LanguageCode }}
-    <language>{{.}}</language>{{end}}{{ with .Site.Author.email }}
-    <managingEditor>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</managingEditor>{{end}}{{ with .Site.Author.email }}
-    <webMaster>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</webMaster>{{end}}{{ with .Site.Copyright }}
+    <language>{{.}}</language>{{end}}{{ with .Site.Copyright }}
     <copyright>{{.}}</copyright>{{end}}{{ if not .Date.IsZero }}
     <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
     {{- with .OutputFormats.Get "RSS" -}}
@@ -30,7 +28,6 @@
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
-      {{- with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | html }}</description>
     </item>


### PR DESCRIPTION
Fixes errors from run https://github.com/devops-actions/github-actions-marketplace-news/actions/runs/24790560593/job/72546559797 after PR #56 merged. 1) .Site.Author was removed in Hugo 0.160.1 - dropped managingEditor, webMaster and per-item author fields from rss.xml (no author was configured anyway, so these were no-ops before). 2) about.md had a menu front matter entry duplicating the hugo.toml menu definition, causing a duplicate menu warning.