### PR TITLE
Fix index page summary display and RSS feed for issue #58

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -11,7 +11,7 @@
   {{- $filteredPages = $filteredPages | first $limit -}}
 {{- end -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
-<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
   <channel>
     <title>{{ if eq  .Title  .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}} on {{ end }}{{ .Site.Title }}{{ end }}</title>
     <link>{{ .Permalink }}</link>
@@ -29,7 +29,8 @@
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | html }}</description>
+      <description>{{ .Summary | plainify }}</description>
+      <content:encoded><![CDATA[{{ .Content }}]]></content:encoded>
     </item>
     {{- end -}}
   </channel>

--- a/layouts/_default/summary-with-image.html
+++ b/layouts/_default/summary-with-image.html
@@ -22,7 +22,7 @@
             {{ end }}
         </h1>
         <div class="f6 f5-l lh-copy nested-copy-line-height nested-links">
-          {{ .Summary }}
+          {{ .Summary | plainify }}
         </div>
           <a href="{{.RelPermalink}}" class="ba b--moon-gray bg-light-gray br2 color-inherit dib f7 hover-bg-moon-gray link mt2 ph2 pv1">{{ $.Param "read_more_copy" | default (i18n "readMore") }}</a>
         {{/* TODO: add author

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -11,7 +11,7 @@
       </a>
     </h1>
     <div class="nested-links f5 lh-copy nested-copy-line-height">
-      {{ .Summary }}
+      {{ .Summary | plainify }}
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes #58

## Changes

### Index page summary
- Changed `{{ .Summary }}` to `{{ .Summary | plainify }}` in both `summary.html` and `summary-with-image.html`
- This strips the HTML section headings (`Action Type`, `Action Summary`) from preview cards, giving clean plain-text summaries instead of large `<h2>` headings cluttering the preview

### RSS feed
- Fixed `<description>` to use `{{ .Summary | plainify }}` — shows clean plain text in RSS reader previews (no more HTML-escaped headings)
- Added `<content:encoded>` with the full post content (including the **What's Changed** section) — satisfies the request to include changelog info in RSS items
- Added `xmlns:content` namespace to the RSS element

## Files changed
- `layouts/_default/rss.xml`
- `layouts/_default/summary.html`
- `layouts/_default/summary-with-image.html`