### PR TITLE
feat: auto-cleanup old posts when site exceeds size threshold during build

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -30,7 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pages: write
       issues: write
     outputs:
@@ -55,6 +55,41 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Auto-cleanup old posts if needed
+        run: |
+          chmod +x ./scripts/auto-cleanup-posts.sh
+          ./scripts/auto-cleanup-posts.sh
+
+          # If files were removed, commit and push before building.
+          # We MUST push successfully to prevent the deployed site from
+          # drifting out of sync with the source repository.
+          if git status --porcelain | grep -qE "^ D content/posts"; then
+            removed_count=$(git diff --name-only content/posts/ | wc -l)
+            git add content/posts/
+            git commit -m "chore: auto-archive old posts during build" \
+                       -m "Automatically removed $removed_count post files during deployment because total post count exceeded the safe threshold (POST_COUNT_THRESHOLD=$POST_COUNT_THRESHOLD)." \
+                       -m "Removed content can be restored from git history if needed."
+
+            echo "Pushing cleanup commit to main..."
+            if ! git push origin HEAD:main; then
+              echo "❌ Failed to push cleanup commit to main."
+              echo "   This may be due to branch protection rules or a non-fast-forward conflict."
+              echo "   Please run the 'Archive Old Posts' workflow manually and retry the deployment."
+              exit 1
+            fi
+            echo "✅ Cleanup committed and pushed ($removed_count files removed)"
+          fi
+        env:
+          POST_COUNT_THRESHOLD: '2000'
+          MAX_MONTHS: '1'
 
       - name: Setup Pages
         id: pages

--- a/scripts/auto-cleanup-posts.sh
+++ b/scripts/auto-cleanup-posts.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Auto-cleanup old posts to keep site within GitHub Pages size limits.
+# Removes the oldest calendar-month directories one at a time until
+# the total post count is within MAX_MONTHS month directories.
+#
+# Env vars:
+#   MAX_MONTHS           - maximum calendar months to retain (default: 1)
+#   POST_COUNT_THRESHOLD - skip cleanup entirely if total posts <= this (default: 2000)
+
+set -e
+
+POSTS_DIR="content/posts"
+MAX_MONTHS="${MAX_MONTHS:-1}"
+POST_COUNT_THRESHOLD="${POST_COUNT_THRESHOLD:-2000}"
+
+if ! [[ "$MAX_MONTHS" =~ ^[0-9]+$ ]] || [ "$MAX_MONTHS" -lt 1 ]; then
+    echo "❌ Error: MAX_MONTHS must be a positive integer (got: '$MAX_MONTHS')"
+    exit 1
+fi
+
+if [ ! -d "$POSTS_DIR" ]; then
+    echo "❌ Error: Posts directory not found: $POSTS_DIR"
+    echo "   This script must be run from the repository root"
+    exit 1
+fi
+
+total_posts=$(find "$POSTS_DIR" -type f -name "*.md" 2>/dev/null | wc -l)
+echo "📊 Total posts: $total_posts (threshold: $POST_COUNT_THRESHOLD, max months: $MAX_MONTHS)"
+
+if [ "$total_posts" -le "$POST_COUNT_THRESHOLD" ]; then
+    echo "✅ Post count within limits, no cleanup needed"
+    exit 0
+fi
+
+echo "⚠️  Post count ($total_posts) exceeds threshold ($POST_COUNT_THRESHOLD). Starting auto-cleanup..."
+echo ""
+
+removed_total=0
+
+# Remove the oldest month directory repeatedly until we are at or below MAX_MONTHS
+while true; do
+    # Collect all YYYY/MM directories sorted oldest-first
+    mapfile -t month_dirs < <(find "$POSTS_DIR" -mindepth 2 -maxdepth 2 -type d | sort)
+    month_count=${#month_dirs[@]}
+
+    if [ "$month_count" -le "$MAX_MONTHS" ]; then
+        echo "ℹ️  Reached target: $month_count month(s) remaining (MAX_MONTHS=$MAX_MONTHS)"
+        break
+    fi
+
+    oldest_dir="${month_dirs[0]}"
+    post_count=$(find "$oldest_dir" -type f -name "*.md" 2>/dev/null | wc -l)
+
+    echo "  📦 Removing oldest month: $oldest_dir ($post_count posts)"
+    rm -rf "$oldest_dir"
+    removed_total=$((removed_total + post_count))
+
+    # Remove empty year directories left behind
+    find "$POSTS_DIR" -mindepth 1 -maxdepth 1 -type d -empty -delete 2>/dev/null || true
+done
+
+echo ""
+total_remaining=$(find "$POSTS_DIR" -type f -name "*.md" 2>/dev/null | wc -l)
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ Auto-cleanup complete!"
+echo "   Posts removed  : $removed_total"
+echo "   Posts remaining: $total_remaining"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Problem

The deploy fails when the Hugo-built site exceeds the 8 GB safety threshold (GitHub Pages hard limit is 10 GB). Even with only 2 months of posts (March + April 2026 ≈ 3726 posts), the built site is 11 GB.

The existing `Archive Old Posts` workflow requires manual intervention to fix this.

## Solution

Add a **pre-build auto-cleanup step** to `hugo.yaml` that runs before Hugo, so we never waste time building an oversized site:

1. Counts total markdown posts in `content/posts`
2. If post count > `POST_COUNT_THRESHOLD` (default: 2000), runs the new `scripts/auto-cleanup-posts.sh` to remove the oldest calendar-month directories, keeping only `MAX_MONTHS` (default: 1) month of content
3. Commits and pushes the removal back to `main` using `GITHUB_TOKEN` — pushes with `GITHUB_TOKEN` do not retrigger workflows, so no loop
4. **Fails the build if the push doesn't succeed** — prevents the deployed site from drifting out of sync with the source repo
5. Proceeds with the Hugo build on the trimmed content
6. The existing post-build size check remains as a final safety net

## Why a new script instead of the existing `archive-old-posts.sh`?

The existing archive script uses a date-cutoff approach (`ARCHIVE_MONTHS=1` gives cutoff = "1 month ago"). With our current content (only March + April 2026), the cutoff falls inside March, so the script keeps both months unchanged — it won't help.

The new `auto-cleanup-posts.sh` instead removes the oldest calendar-month **directories by count** until only `MAX_MONTHS` months remain, which reliably reduces content regardless of how few months exist.

## Files changed

- `.github/workflows/hugo.yaml` — permissions `contents: read` → `write`, token on checkout, Configure Git step, new pre-build cleanup step
- `scripts/auto-cleanup-posts.sh` — new script: removes oldest month dirs until `MAX_MONTHS` months remain