### PR TITLE
fix: decode HTML entities in RSS description field

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -29,7 +29,7 @@
       <link>{{ .Permalink }}</link>
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       <guid>{{ .Permalink }}</guid>
-      <description>{{ .Summary | plainify }}</description>
+      <description>{{ .Summary | plainify | htmlUnescape | htmlEscape }}</description>
       <content:encoded><![CDATA[{{ .Content }}]]></content:encoded>
     </item>
     {{- end -}}


### PR DESCRIPTION
## Problem

The RSS feed at `/index.xml` throws an XML parse error:
> Entity 'rsquo' not defined

`plainify` strips HTML tags but leaves named HTML entities like `&rsquo;` as literal text. RSS is XML, and XML only recognises 5 built-in entities (`&amp;`, `&lt;`, `&gt;`, `&apos;`, `&quot;`). Any others cause a parse error.

## Fix

One-liner in `layouts/_default/rss.xml`:

```
{{ .Summary | plainify | htmlUnescape | htmlEscape }}
```

1. `htmlUnescape` — converts `&rsquo;` → `'`, `&amp;` → `&`, etc. (Unicode chars, valid in UTF-8 XML)
2. `htmlEscape` — re-encodes anything XML cares about: `&` → `&amp;`, `<` → `&lt;`, etc.

The `content:encoded` field was already safe because it uses `<![CDATA[...]]>`.