### PR TITLE
fix: use printf+safeHTML to emit CDATA markers in RSS content:encoded

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -30,7 +30,7 @@
       <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
       <guid>{{ .Permalink }}</guid>
       <description>{{ .Summary | plainify | htmlUnescape | htmlEscape }}</description>
-      <content:encoded><![CDATA[{{ .Content }}]]></content:encoded>
+      <content:encoded>{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</content:encoded>
     </item>
     {{- end -}}
   </channel>


### PR DESCRIPTION
## Problem

The RSS `content:encoded` field was producing invalid XML because `<![CDATA[` was being emitted as `&lt;![CDATA[`. This means the CDATA section never actually opened, so `&rsquo;` and other named HTML entities inside the content were parsed as raw XML entities (which are undefined in XML), causing feed parse errors.

**Root cause:** Hugo uses `html/template` for all layouts including `rss.xml`. The `html/template` engine escapes the literal `<` in `<![CDATA[` to `&lt;` — it doesn't understand CDATA as a special XML construct.

## Fix

Build the CDATA wrapper via `printf` and mark it `safeHTML` so `html/template` outputs it verbatim:

```diff
- <content:encoded><![CDATA[{{ .Content }}]]></content:encoded>
+ <content:encoded>{{ printf "<![CDATA[%s]]>" .Content | safeHTML }}</content:encoded>
```

`content:encoded` is designed to carry HTML markup. RSS readers process the HTML inside CDATA correctly, including named HTML entities like `&rsquo;` — so no further escaping is needed inside the CDATA section.