### PR TITLE
feat: add pre-build content fixer to prevent Hugo shortcode parse errors

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -91,6 +91,33 @@ jobs:
           POST_COUNT_THRESHOLD: '2000'
           MAX_MONTHS: '1'
 
+      - name: Fix Hugo content issues
+        run: |
+          chmod +x ./scripts/fix-hugo-content.sh
+          set +e
+          ./scripts/fix-hugo-content.sh
+          fix_exit_code=$?
+          set -e
+
+          # Exit code 0 = no changes, exit code 2 = files were fixed
+          if [ $fix_exit_code -eq 2 ]; then
+            fixed_count=$(git diff --name-only content/ | wc -l)
+            git add content/
+            git commit -m "fix: auto-fix Hugo shortcode syntax issues in content"
+
+            echo "Pushing content fixes to ${GITHUB_REF_NAME}..."
+            if ! git push origin "HEAD:${GITHUB_REF_NAME}"; then
+              echo "❌ Failed to push content fixes."
+              echo "   This may be due to branch protection rules or a non-fast-forward conflict."
+              echo "   Please retry the workflow run."
+              exit 1
+            fi
+            echo "✅ Content fixes committed and pushed ($fixed_count file(s))"
+          elif [ $fix_exit_code -ne 0 ]; then
+            echo "❌ Content fixer failed with unexpected exit code $fix_exit_code"
+            exit 1
+          fi
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -37,9 +37,25 @@ jobs:
 
 ## Hugo Build Error Handling
 
+### Pre-Build Content Fixer
+
+Before Hugo runs, `scripts/fix-hugo-content.sh` scans all markdown files and
+automatically repairs patterns that would cause parse errors. This prevents
+content from needing to be removed in the first place.
+
+**Currently fixed patterns:**
+- `{{< … >}}` / `{{% … %}}` where the shortcode "name" is an invalid
+  character (e.g., U+2026 `…`). Hugo's parser requires shortcode names to
+  start with `[a-zA-Z0-9_-]`; anything else is escaped with comment markers
+  (`{{</* … */>}}`) so Hugo skips parsing but still renders the literal text.
+
+If the fixer modifies any files, it commits and pushes them to the branch
+before the build proceeds.
+
 ### Automatic Recovery and Issue Creation
 
-When Hugo build failures occur, the repository uses an automatic recovery system:
+When a build failure cannot be auto-fixed, the repository falls back to a
+file-removal recovery system:
 
 **Workflow:**
 1. **Build Attempt**: Hugo tries to build the site
@@ -56,6 +72,7 @@ When Hugo build failures occur, the repository uses an automatic recovery system
 9. **Workflow Failure**: The workflow is marked as failed to alert maintainers
 
 **Scripts:**
+- `scripts/fix-hugo-content.sh`: Pre-build content fixer (runs before build)
 - `scripts/build-hugo-with-recovery.sh`: Handles build recovery
 - `scripts/create-issue-for-failed-posts.sh`: Creates GitHub issues
 

--- a/scripts/fix-hugo-content.sh
+++ b/scripts/fix-hugo-content.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Pre-build fixer for Hugo markdown content.
+# Escapes shortcode-like syntax with invalid names so Hugo's parser can proceed.
+#
+# Hugo shortcode names must start with [a-zA-Z0-9_-]. Content imported from
+# external sources sometimes includes patterns like {{< … >}} (documentation
+# examples) where the "name" is a non-ASCII character. Hugo attempts to parse
+# these and fails with "unrecognized character in shortcode action".
+#
+# Fix: wrap with Hugo comment markers ({{</* ... */>}}) so Hugo skips parsing
+# while still rendering the literal text in the output.
+#
+# Usage: ./scripts/fix-hugo-content.sh [content-dir]
+# Exit:  0 = no changes needed, 2 = one or more files were fixed
+
+CONTENT_DIR="${1:-content}"
+fixed_files=0
+total_files=0
+
+echo "🔍 Scanning Hugo content for fixable shortcode issues..."
+
+while IFS= read -r -d '' file; do
+    total_files=$((total_files + 1))
+
+    cp "$file" "$file.bak"
+
+    # Escape {{< ... >}} and {{% ... %}} patterns whose "shortcode name" is invalid.
+    # A valid Hugo shortcode name starts with [a-zA-Z0-9_-].  If the first
+    # non-space character after {{< is not in that set, Hugo will reject it.
+    # We escape such patterns with comment markers so Hugo skips them.
+    #
+    # Lookahead (?!\/\*) prevents double-escaping already-fixed content.
+    perl -0777 -i -pe '
+        # {{< INVALID ... >}} → {{</* INVALID ... */>}}
+        s/\{\{<(?!\/\*)(\s*[^\sa-zA-Z0-9_\-](?:(?!>\}\}).)*?)>\}\}/{{<\/* $1 *\/>}}/g;
+        # {{% INVALID ... %}} → {{%/* INVALID ... */%}}
+        s/\{\{%(?!\/\*)(\s*[^\sa-zA-Z0-9_\-](?:(?!%\}\}).)*?)%\}\}/{{%\/* $1 *\/%}}/g;
+    ' "$file"
+
+    if ! diff -q "$file.bak" "$file" > /dev/null 2>&1; then
+        changes=$(diff "$file.bak" "$file" | grep -c "^[<>]" || true)
+        echo "  ✅ Fixed $changes pattern(s) in: $file"
+        fixed_files=$((fixed_files + 1))
+    fi
+    rm -f "$file.bak"
+done < <(find "$CONTENT_DIR" -name "*.md" -print0)
+
+echo ""
+if [ "$fixed_files" -eq 0 ]; then
+    echo "✅ Scanned $total_files files — no issues found"
+    exit 0
+else
+    echo "✅ Scanned $total_files files — fixed $fixed_files file(s)"
+    exit 2
+fi


### PR DESCRIPTION
Adds a pre-build linting/fixing step that automatically repairs markdown content before Hugo runs.

New `scripts/fix-hugo-content.sh` scans all content markdown files and escapes shortcode-like patterns whose 'name' is not a valid Hugo identifier (must start with [a-zA-Z0-9_-]).

- `{{< ... >}}` with invalid name -> `{{</* ... */>}}` (Hugo skips parsing, renders literal text)
- Idempotent: already-escaped patterns left untouched
- Valid shortcodes (`{{< figure ... >}}`) never touched

New **Fix Hugo content issues** step in `hugo.yaml` runs after auto-cleanup, before the build. Commits and pushes any fixes back to the branch automatically.

Closes the pattern that caused: https://github.com/devops-actions/github-actions-marketplace-news/actions/runs/26171590670/job/76990501370